### PR TITLE
Fix various boss softlocks and unintended permacharms with IV. The Emperor

### DIFF
--- a/cards/theEmperor.lua
+++ b/cards/theEmperor.lua
@@ -17,8 +17,7 @@ local function MC_USE_CARD(_, c, p)
 		local entity = v:ToNPC()
 		if entity then
 			local parent = entity.SpawnerType or 0
-			print(parent)
-	        if entity:GetBossID() == 0 and not helper.TableContains(illegalParents, parent) then
+	        if not entity:IsBoss() and entity:IsVulnerableEnemy() and not helper.TableContains(illegalParents, parent) then
 				entity:AddCharmed(EntityRef(p), -1)
 	        end
 		end

--- a/helper_functions.lua
+++ b/helper_functions.lua
@@ -223,12 +223,6 @@ end
 
 function H.IsEntityInTable(table, entity)
 	for _,v in pairs(table) do
-		-- print(entity.Type)
-		-- print(v[1])
-		-- print(entity.Variant)
-		-- print(v[2])
-		-- print(entity.SubType)
-		-- print(v[3])
 		if entity.Type == v[1]
 		and entity.Variant == v[2] or nil
 		and entity.SubType == v[3] or nil then


### PR DESCRIPTION
Gemini's cord and enemies spawned by Haunt, Forsaken, and Heretic cannot be permacharmed.
Vulnerable enemies, minibosses, and non-NPCs, cannot be permacharmed.
Resolves #12 and #17.