### PR TITLE
XV. The Devil and IX. The Hermit item spawns will try to avoid player position

### DIFF
--- a/cards/theDevil.lua
+++ b/cards/theDevil.lua
@@ -11,7 +11,7 @@ local function MC_USE_CARD(_, c, p)
     local itemPool = game:GetItemPool()
     local room = game:GetRoom()
     local collectible = itemPool:GetCollectible(itemPool:GetPoolForRoom(room:GetType(), lootdeck.rng:GetSeed()))
-    local spawnPos = room:FindFreePickupSpawnPosition(p.Position)
+    local spawnPos = room:FindFreePickupSpawnPosition(p.Position, 0, true)
     local spawnedItem = Isaac.Spawn(EntityType.ENTITY_PICKUP, PickupVariant.PICKUP_COLLECTIBLE, collectible, spawnPos, Vector.Zero, nil):ToPickup()
     spawnedItem.AutoUpdatePrice = false
     if helper.IsSoulHeartMarty(p) then

--- a/cards/theHermit.lua
+++ b/cards/theHermit.lua
@@ -9,7 +9,7 @@ local function MC_USE_CARD(_, c, p)
     local itemPool = game:GetItemPool()
     local room = game:GetRoom()
     local collectible = itemPool:GetCollectible(itemPool:GetPoolForRoom(room:GetType(), lootdeck.rng:GetSeed()))
-    local spawnPos = room:FindFreePickupSpawnPosition(p.Position)
+    local spawnPos = room:FindFreePickupSpawnPosition(p.Position, 0, true)
     local spawnedItem = Isaac.Spawn(EntityType.ENTITY_PICKUP, PickupVariant.PICKUP_COLLECTIBLE, collectible, spawnPos, Vector.Zero, p):ToPickup()
     Isaac.Spawn(EntityType.ENTITY_EFFECT, EffectVariant.POOF01, 0, spawnPos, Vector.Zero, p)
     spawnedItem.AutoUpdatePrice = true


### PR DESCRIPTION
Resolves #14.
NOTE:
This just enables the `AvoidActiveEntities` parameter in `FindFreePickupSpawnPosition()`. On game startup, the player might not count as an active entity until you move, so move a little bit before testing just in case. This shouldn't be an issue in natural gameplay.