### PR TITLE
Multiple Swallowed Pennies only spawn 1 penny, but with increased chances of spawning.

### DIFF
--- a/items/swallowedPenny.lua
+++ b/items/swallowedPenny.lua
@@ -5,11 +5,12 @@ local Id = Isaac.GetItemIdByName(Name)
 
 local function MC_ENTITY_TAKE_DMG(_, e)
     local rng = lootdeck.rng
-    if e:ToPlayer():HasCollectible(Id) then
-        for i=1,e:ToPlayer():GetCollectibleNum(Id) do
+    local p = e:ToPlayer()
+    if p:HasCollectible(Id) then
+        for i=1,p:GetCollectibleNum(Id) do
             local effect = rng:RandomInt(2)
             if effect == 0 then
-                Isaac.Spawn(EntityType.ENTITY_PICKUP, PickupVariant.PICKUP_COIN, 0, (e.Position), Vector.FromAngle(rng:RandomInt(360)), nil)
+                Isaac.Spawn(EntityType.ENTITY_PICKUP, PickupVariant.PICKUP_COIN, CoinSubType.COIN_PENNY, p.Position, Vector.FromAngle(rng:RandomInt(360)), nil)
 				break
 			end
         end


### PR DESCRIPTION
Basically two Swallowed Pennies = two 50/50s = 75% chance at 1 penny
and three Swallowed Pennies = three 50/50s = 87.5% chance at 1 penny.
Resolves #9 