### PR TITLE
hiero persists between rooms, better mantle damage detection

### DIFF
--- a/cards/soulHeart.lua
+++ b/cards/soulHeart.lua
@@ -15,14 +15,16 @@ local function MC_USE_CARD(_, c, p)
 	p:AddNullCostume(costumes.mantle)
 end
 
-local function MC_ENTITY_TAKE_DMG(_, e)
+local function MC_ENTITY_TAKE_DMG(_, e, damageAmount, damageFlags, damageSource)
     local p = e:ToPlayer()
     local data = p:GetData()
     if data[Tag] then
-		p:TryRemoveNullCostume(costumes.mantle)
-        helper.HolyMantleEffect(p)
-        data[Tag] = nil
-        return false
+        if helper.HolyMantleDamage(damageAmount, damageFlags, damageSource) then
+    		p:TryRemoveNullCostume(costumes.mantle)
+            helper.HolyMantleEffect(p)
+            data[Tag] = nil
+            return false
+        end
     end
 end
 

--- a/cards/theHierophant.lua
+++ b/cards/theHierophant.lua
@@ -15,18 +15,20 @@ local function MC_USE_CARD(_, c, p)
 	p:AddNullCostume(costumes.mantle)
 end
 
-local function MC_ENTITY_TAKE_DMG(_, e)
+local function MC_ENTITY_TAKE_DMG(_, e, damageAmount, damageFlags, damageSource)
     local p = e:ToPlayer()
     local data = p:GetData()
     if data[Tag] and data[Tag] > 0 then
-        helper.HolyMantleEffect(p)
-        data[Tag] = data[Tag] - 1
-		p:TryRemoveNullCostume(costumes.mantle)
-		p:TryRemoveNullCostume(costumes.mantleBroken)
-		if data[Tag] == 1 then
-			p:AddNullCostume(costumes.mantleBroken)
-		end
-        return false
+        if helper.HolyMantleDamage(damageAmount, damageFlags, damageSource) then
+            helper.HolyMantleEffect(p)
+            data[Tag] = data[Tag] - 1
+    		p:TryRemoveNullCostume(costumes.mantle)
+    		p:TryRemoveNullCostume(costumes.mantleBroken)
+    		if data[Tag] == 1 then
+    			p:AddNullCostume(costumes.mantleBroken)
+    		end
+            return false
+        end
     else
         data[Tag] = nil
     end
@@ -34,9 +36,13 @@ end
 
 local function MC_POST_NEW_ROOM()
     helper.ForEachPlayer(function(p, data)
-        data[Tag] = nil
-		p:TryRemoveNullCostume(costumes.mantle)
-		p:TryRemoveNullCostume(costumes.mantleBroken)
+        if data[Tag] then
+            if data[Tag] == 2 then
+                p:AddNullCostume(costumes.mantle)
+            elseif data[Tag] == 1 then
+                p:AddNullCostume(costumes.mantleBroken)
+            end
+        end
     end)
 end
 

--- a/cards/theHierophant.lua
+++ b/cards/theHierophant.lua
@@ -2,18 +2,11 @@ local helper = include("helper_functions")
 local costumes = include("costumes/registry")
 
 -- Gives two Holy Mantle effects for the room (negates damage twice with minimal cooldown)
-local Names = {
-    en_us = "V. The Hierophant",
-    spa = "V. EL Hierofante"
-}
-local Name = Names.en_us
+local Name = "V. The Hierophant"
 local Tag = "theHierophant"
 local Id = Isaac.GetCardIdByName(Name)
 local Weight = 1
-local Descriptions = {
-    en_us = "Grants a {{Collectible313}} Holy Mantle effect that can absorb two hits for the room",
-    spa = "Otorga el efecto del {{Collectible313}} Manto Sagrado"
-}
+local Description = "Grants a {{Collectible313}} Holy Mantle effect that can absorb two hits for the room"
 local WikiDescription = helper.GenerateEncyclopediaPage("Grants a unique Holy Mantle that can absorb two hits for the duration of the room.")
 
 local function MC_USE_CARD(_, c, p)
@@ -25,6 +18,7 @@ end
 local function MC_ENTITY_TAKE_DMG(_, e, damageAmount, damageFlags, damageSource)
     local p = e:ToPlayer()
     local data = p:GetData()
+    print(damageSource.Type)
     if data[Tag] and data[Tag] > 0 then
         if helper.HolyMantleDamage(damageAmount, damageFlags, damageSource) then
             helper.HolyMantleEffect(p)
@@ -44,22 +38,30 @@ end
 local function MC_POST_NEW_ROOM()
     helper.ForEachPlayer(function(p, data)
         if data[Tag] then
+            data[Tag .. "KeepCostume"] = true
+        end
+    end)
+end
+
+local function MC_POST_UPDATE()
+    helper.ForEachPlayer(function(p, data)
+        if data[Tag .. "KeepCostume"] then
             if data[Tag] == 2 then
                 p:AddNullCostume(costumes.mantle)
             elseif data[Tag] == 1 then
                 p:AddNullCostume(costumes.mantleBroken)
             end
+            data[Tag .. "KeepCostume"] = false
         end
     end)
 end
 
 return {
     Name = Name,
-    Names = Names,
     Tag = Tag,
 	Id = Id,
     Weight = Weight,
-    Descriptions = Descriptions,
+    Description = Description,
     WikiDescription = WikiDescription,
     callbacks = {
         {
@@ -75,6 +77,10 @@ return {
         {
             ModCallbacks.MC_POST_NEW_ROOM,
             MC_POST_NEW_ROOM
-		}
+		},
+        {
+            ModCallbacks.MC_POST_UPDATE,
+            MC_POST_UPDATE
+		},
     }
 }

--- a/helper_functions.lua
+++ b/helper_functions.lua
@@ -246,6 +246,9 @@ function H.HolyMantleDamage(damageAmount, damageFlags, damageSource)
     if (Game():GetRoom():GetType() == RoomType.ROOM_SACRIFICE and damageSource.Type == 0) then
         includeFlags = includeFlags | DamageFlag.DAMAGE_SPIKES
     end
+    if (Game():GetRoom():GetType() == RoomType.ROOM_SHOP and damageSource.Type == 0 and (damageFlags & (DamageFlag.DAMAGE_NO_PENALTIES | DamageFlag.DAMAGE_SPIKES) ~= 0)) then
+        ignoreFlags = ignoreFlags | DamageFlag.DAMAGE_SPIKES
+    end
     if damageAmount > 0
     and ((damageSource and damageSource.Type ~= EntityType.ENTITY_SLOT) or not damageSource)
     and ((damageFlags & ignoreFlags == 0) or (damageFlags & includeFlags ~= 0)) then
@@ -254,10 +257,10 @@ function H.HolyMantleDamage(damageAmount, damageFlags, damageSource)
     return false
 end
 
-function H.HolyMantleEffect(p, damageCooldown)
+function H.HolyMantleEffect(p)
     lootdeck.sfx:Play(SoundEffect.SOUND_HOLY_MANTLE,1,0)
     Isaac.Spawn(EntityType.ENTITY_EFFECT, EffectVariant.POOF02, 11, p.Position, Vector.Zero, p)
-    p:SetMinDamageCooldown(damageCooldown or 30)
+    p:SetMinDamageCooldown(30)
 end
 
 function H.CheckFinalFloorBossKilled()

--- a/helper_functions.lua
+++ b/helper_functions.lua
@@ -240,6 +240,20 @@ function H.IsEntityInTable(table, entity)
 	return false
 end
 
+function H.HolyMantleDamage(damageAmount, damageFlags, damageSource)
+    local ignoreFlags = DamageFlag.DAMAGE_DEVIL | DamageFlag.DAMAGE_IV_BAG | DamageFlag.DAMAGE_FAKE | DamageFlag.DAMAGE_RED_HEARTS
+    local includeFlags = DamageFlag.DAMAGE_CURSED_DOOR
+    if (Game():GetRoom():GetType() == RoomType.ROOM_SACRIFICE and damageSource.Type == 0) then
+        includeFlags = includeFlags | DamageFlag.DAMAGE_SPIKES
+    end
+    if damageAmount > 0
+    and ((damageSource and damageSource.Type ~= EntityType.ENTITY_SLOT) or not damageSource)
+    and ((damageFlags & ignoreFlags == 0) or (damageFlags & includeFlags ~= 0)) then
+        return true
+    end
+    return false
+end
+
 function H.HolyMantleEffect(p, damageCooldown)
     lootdeck.sfx:Play(SoundEffect.SOUND_HOLY_MANTLE,1,0)
     Isaac.Spawn(EntityType.ENTITY_EFFECT, EffectVariant.POOF02, 11, p.Position, Vector.Zero, p)

--- a/items/guppysHairball.lua
+++ b/items/guppysHairball.lua
@@ -11,8 +11,10 @@ local function MC_ENTITY_TAKE_DMG(_, e)
     local p = e:ToPlayer()
     if p:HasCollectible(Id) then
         if helper.PercentageChance(100 / 6 * p:GetCollectibleNum(Id), 50) then
-            helper.HolyMantleEffect(p)
-            return false
+            if helper.HolyMantleDamage(damageAmount, damageFlags, damageSource) then
+                helper.HolyMantleEffect(p)
+                return false
+            end
         end
     end
 end

--- a/items/guppysHairball.lua
+++ b/items/guppysHairball.lua
@@ -7,7 +7,7 @@ local Id = Isaac.GetItemIdByName(Name)
 local Description = "Every instance of damage taken has a 1/6 chance to be blocked"
 local WikiDescription = helper.GenerateEncyclopediaPage("Every instance of damage taken has a 1/6 chance to be blocked.", "- Additional copies of the passive add an extra 1/6 chance, up to 3/6.")
 
-local function MC_ENTITY_TAKE_DMG(_, e)
+local function MC_ENTITY_TAKE_DMG(_, e, damageAmount, damageFlags, damageSource)
     local p = e:ToPlayer()
     if p:HasCollectible(Id) then
         if helper.PercentageChance(100 / 6 * p:GetCollectibleNum(Id), 50) then


### PR DESCRIPTION
Resolves myself

For testing stuff:
Mantle protection should be ignored on:
IV Bag, Razor Blade, Blood Rights, Dull Razor (All Items)
Blood Donation Machines & Devil Beggars
Buying a pickup from a store with Pound of Flesh (Item)

Mantle protection should still occur on:
Curse Room Doors
Sacrifice Room Spikes
Spikes in Devil Room from Sanguine Bond (Item)
Enemies and hazards and shit

The following cards will be affected: V. The Hierophant, Soul Heart, and Guppy's Hairball.