### PR TITLE
Fix cards not showing when using Loot Deck and blip of card use animation on pickup animation

### DIFF
--- a/cards/registry.lua
+++ b/cards/registry.lua
@@ -79,7 +79,6 @@ local cards = {
 local holoCards = {}
 
 for key, card in pairs(cards) do
-    Isaac.DebugString(key)
     card.HUDAnimationName = "Idle"
     card.PickupAnimationName = "Idle"
     card.UseAnimationName = "IdleFast"

--- a/helper_functions.lua
+++ b/helper_functions.lua
@@ -1143,7 +1143,9 @@ function H.PlayLootcardPickupAnimation(data, id)
 
         H.StartLootcardAnimation(data.lootcardPickupAnimation, card.Tag, animationName)
         data.isHoldingLootcard = true
-        data.lootcardUseAnimation:SetLastFrame()
+        if data.lootcardUseAnimation then
+            data.lootcardUseAnimation:SetLastFrame()
+        end
     end
 end
 
@@ -1158,7 +1160,9 @@ function H.PlayLootcardUseAnimation(data, id)
         data.lootcardUseAnimation = H.RegisterAnimation(data.lootcardUseAnimation, "gfx/ui/item_dummy_animation.anm2", animationName)
 
         H.StartLootcardAnimation(data.lootcardUseAnimation, card.Tag, animationName)
-        data.lootcardPickupAnimation:SetLastFrame()
+        if data.lootcardPickupAnimation then
+            data.lootcardPickupAnimation:SetLastFrame()
+        end
     end
 end
 

--- a/helper_functions.lua
+++ b/helper_functions.lua
@@ -1143,6 +1143,7 @@ function H.PlayLootcardPickupAnimation(data, id)
 
         H.StartLootcardAnimation(data.lootcardPickupAnimation, card.Tag, animationName)
         data.isHoldingLootcard = true
+        data.lootcardUseAnimation:SetLastFrame()
     end
 end
 
@@ -1157,6 +1158,7 @@ function H.PlayLootcardUseAnimation(data, id)
         data.lootcardUseAnimation = H.RegisterAnimation(data.lootcardUseAnimation, "gfx/ui/item_dummy_animation.anm2", animationName)
 
         H.StartLootcardAnimation(data.lootcardUseAnimation, card.Tag, animationName)
+        data.lootcardPickupAnimation:SetLastFrame()
     end
 end
 

--- a/helper_functions.lua
+++ b/helper_functions.lua
@@ -1114,8 +1114,11 @@ function H.GetCardPositionWithHUDOffset(p, sprite)
 end
 
 function H.RegisterAnimation(animationContainer, animationPath, animationName, callback)
-    if not animationContainer then
-        animationContainer = H.RegisterSprite(animationPath, nil, animationName)
+    if not animationContainer or not animationContainer.sprite then
+        animationContainer = {
+            sprite = H.RegisterSprite(animationPath, nil, animationName),
+            frameCount = 0
+        }
         if callback then
             callback(animationContainer)
         end
@@ -1124,10 +1127,11 @@ function H.RegisterAnimation(animationContainer, animationPath, animationName, c
 end
 
 function H.StartLootcardAnimation(lootcardAnimationContainer, lootcardTag, animationName)
-    lootcardAnimationContainer:ReplaceSpritesheet(0, string.format("gfx/ui/lootcard_fronts/%s.png", lootcardTag:gsub("holographic", "")))
-    lootcardAnimationContainer:LoadGraphics()
+    lootcardAnimationContainer.sprite:ReplaceSpritesheet(0, string.format("gfx/ui/lootcard_fronts/%s.png", lootcardTag:gsub("holographic", "")))
+    lootcardAnimationContainer.sprite:LoadGraphics()
     if animationName then
-        lootcardAnimationContainer:Play(animationName, true)
+        lootcardAnimationContainer.sprite:Play(animationName, true)
+        lootcardAnimationContainer.frameCount = Isaac.GetFrameCount()
     end
 end
 
@@ -1144,7 +1148,7 @@ function H.PlayLootcardPickupAnimation(data, id)
         H.StartLootcardAnimation(data.lootcardPickupAnimation, card.Tag, animationName)
         data.isHoldingLootcard = true
         if data.lootcardUseAnimation then
-            data.lootcardUseAnimation:SetLastFrame()
+            data.lootcardUseAnimation.sprite:SetLastFrame()
         end
     end
 end
@@ -1161,7 +1165,7 @@ function H.PlayLootcardUseAnimation(data, id)
 
         H.StartLootcardAnimation(data.lootcardUseAnimation, card.Tag, animationName)
         if data.lootcardPickupAnimation then
-            data.lootcardPickupAnimation:SetLastFrame()
+            data.lootcardPickupAnimation.sprite:SetLastFrame()
         end
     end
 end

--- a/items/lootDeck.lua
+++ b/items/lootDeck.lua
@@ -22,7 +22,7 @@ local function MC_USE_ITEM(_, type, rng, p)
 
     local data = p:GetData()
     if data.lootcardPickupAnimation then
-        data.lootcardPickupAnimation:SetLastFrame()
+        data.lootcardPickupAnimation.sprite:SetLastFrame()
     end
     if heldLootcard then
         helper.PlayLootcardUseAnimation(data, heldLootcard.Id)

--- a/main.lua
+++ b/main.lua
@@ -337,7 +337,7 @@ lootdeck:AddCallback(ModCallbacks.MC_POST_PLAYER_RENDER, function(_, p)
     end
     local offsetVector = Vector(0,12) - p.PositionOffset - flyingOffset
 
-    if (playerAnimation == "UseItem" or playerAnimation == "Pickup" or playerAnimation == "PickupWalkDown" or playerAnimation == "PickupWalkUp" or playerAnimation == "PickupWalkLeft" or playerAnimation == "PickupWalkRight") then
+    if ((playerAnimation == "UseItem" and p:GetActiveItem() == items.lootDeck.Id) or playerAnimation == "Pickup" or playerAnimation == "PickupWalkDown" or playerAnimation == "PickupWalkUp" or playerAnimation == "PickupWalkLeft" or playerAnimation == "PickupWalkRight") then
         if data.isHoldingLootcard and data.lootcardPickupAnimation and data.lootcardPickupAnimation:IsPlaying(data.lootcardPickupAnimation:GetAnimation()) then
             if (Isaac.GetFrameCount() % 2) == 0 and not Game():IsPaused() then
                 data.lootcardPickupAnimation:Update()

--- a/main.lua
+++ b/main.lua
@@ -131,125 +131,6 @@ lootdeck:AddCallback(ModCallbacks.MC_POST_NEW_ROOM, function()
 
 end)
 
-for _, card in pairs(lootcards) do
-    if card.callbacks then
-        for _, callback in pairs(card.callbacks) do
-            if callback[1] == ModCallbacks.MC_USE_CARD then
-                lootdeck:AddCallback(callback[1], function(_, c, p, f)
-                    local shouldDouble = card.Holographic or items.playerCard.helpers.ShouldRunDouble(p)
-                    local result = callback[2](_, c, p, f, shouldDouble)
-
-                    if shouldDouble and callback[4] then
-                        if not callback[5] then
-                            callback[2](_, c, p, f)
-                        else
-                            table.insert(lootdeck.f.delayedCards, {
-                                player = p,
-                                cardId = c,
-                                flags = f,
-                                delay = callback[5] * 30
-                            })
-                        end
-                    end
-
-                    if f & UseFlag.USE_MIMIC == 0 then
-                        local data = p:GetData()
-                        if result == nil or result then
-                            helper.PlayLootcardUseAnimation(data, card.Id)
-                        end
-                        data.isHoldingLootcard = false
-                    end
-                end, card.Id)
-            else
-                lootdeck:AddCallback(table.unpack(callback))
-            end
-        end
-    end
-
-    helper.AddExternalItemDescriptionCard(card)
-
-	if Encyclopedia and card.WikiDescription and not card.Holographic then
-		local cardFrontPath = string.format("gfx/ui/lootcard_fronts/%s.png", card.Tag)
-		Encyclopedia.AddCard({
-			Class = "Loot Deck",
-			ID = card.Id,
-			WikiDesc = card.WikiDescription,
-			ModName = "Loot Deck",
-			Spr = Encyclopedia.RegisterSprite("gfx/ui/lootcard_fronts.anm2", card.HUDAnimationName, 0, cardFrontPath),
-		})
-	end
-end
-
-for _, challenge in pairs(lootdeckChallenges) do
-    if challenge.callbacks then
-        for _, callback in pairs(challenge.callbacks) do
-            lootdeck:AddCallback(table.unpack(callback))
-        end
-    end
-end
-
-for _, variant in pairs(entityVariants) do
-    if variant.callbacks then
-        for _, callback in pairs(variant.callbacks) do
-            lootdeck:AddCallback(table.unpack(callback))
-        end
-    end
-end
-
-for _, subType in pairs(entitySubTypes) do
-    if subType.callbacks then
-        for _, callback in pairs(subType.callbacks) do
-            lootdeck:AddCallback(table.unpack(callback))
-        end
-    end
-end
-
-for _, item in pairs(items) do
-    if item.callbacks then
-        for _, callback in pairs(item.callbacks) do
-            lootdeck:AddCallback(table.unpack(callback))
-        end
-    end
-
-	helper.AddExternalItemDescriptionItem(item)
-
-	if Encyclopedia and item.WikiDescription then
-		Encyclopedia.AddItem({
-			Class = "Loot Deck",
-			ID = item.Id,
-			WikiDesc = item.WikiDescription,
-			ModName = "Loot Deck"
-		})
-	end
-end
-
-for _, trinket in pairs(trinkets) do
-    if trinket.callbacks then
-        for _, callback in pairs(trinket.callbacks) do
-            lootdeck:AddCallback(table.unpack(callback))
-        end
-    end
-
-	helper.AddExternalItemDescriptionTrinket(trinket)
-
-	if Encyclopedia and trinket.WikiDescription then
-		Encyclopedia.AddTrinket({
-			Class = "Loot Deck",
-			ID = trinket.Id,
-			WikiDesc = trinket.WikiDescription,
-			ModName = "Loot Deck"
-		})
-	end
-end
-
-for _, trinket in pairs(trinkets) do
-    if trinket.callbacks then
-        for _, callback in pairs(trinket.callbacks) do
-            lootdeck:AddCallback(table.unpack(callback))
-        end
-    end
-end
-
 lootdeck:AddCallback(ModCallbacks.MC_POST_UPDATE, function()
     if lootdeck.f.delayedCards then
         for i, delayedCard in pairs(lootdeck.f.delayedCards) do
@@ -456,10 +337,38 @@ lootdeck:AddCallback(ModCallbacks.MC_POST_RENDER, function()
     end)
 end)
 
+lootdeck:AddCallback(ModCallbacks.MC_USE_CARD, function(_, c, p)
+    local data = p:GetData()
+
+    if data.lootcardPickupAnimation then
+        data.lootcardPickupAnimation.sprite:SetLastFrame()
+    end
+
+    if data.lootcardUseAnimation then
+        data.lootcardUseAnimation.sprite:SetLastFrame()
+    end
+end)
+
+lootdeck:AddCallback(ModCallbacks.MC_USE_ITEM, function(_, type, rng, p)
+    local data = p:GetData()
+
+    if data.lootcardPickupAnimation then
+        data.lootcardPickupAnimation.sprite:SetLastFrame()
+    end
+    
+    if data.lootcardUseAnimation then
+        data.lootcardUseAnimation.sprite:SetLastFrame()
+    end
+end)
+
 lootdeck:AddCallback(ModCallbacks.MC_USE_ITEM, function(_, type, rng, p)
     local heldLootcard = helper.GetLootcardById(p:GetCard(0))
 
     local data = p:GetData()
+
+    if data.lootcardPickupAnimation then
+        data.lootcardPickupAnimation.sprite:SetLastFrame()
+    end
 
     if data.lootcardUseAnimation then
         data.lootcardUseAnimation.sprite:SetLastFrame()
@@ -469,3 +378,122 @@ lootdeck:AddCallback(ModCallbacks.MC_USE_ITEM, function(_, type, rng, p)
         helper.PlayLootcardUseAnimation(data, heldLootcard.Id)
     end
 end, CollectibleType.COLLECTIBLE_DECK_OF_CARDS)
+
+for _, card in pairs(lootcards) do
+    if card.callbacks then
+        for _, callback in pairs(card.callbacks) do
+            if callback[1] == ModCallbacks.MC_USE_CARD then
+                lootdeck:AddCallback(callback[1], function(_, c, p, f)
+                    local shouldDouble = card.Holographic or items.playerCard.helpers.ShouldRunDouble(p)
+                    local result = callback[2](_, c, p, f, shouldDouble)
+
+                    if shouldDouble and callback[4] then
+                        if not callback[5] then
+                            callback[2](_, c, p, f)
+                        else
+                            table.insert(lootdeck.f.delayedCards, {
+                                player = p,
+                                cardId = c,
+                                flags = f,
+                                delay = callback[5] * 30
+                            })
+                        end
+                    end
+
+                    if f & UseFlag.USE_MIMIC == 0 then
+                        local data = p:GetData()
+                        if result == nil or result then
+                            helper.PlayLootcardUseAnimation(data, card.Id)
+                        end
+                        data.isHoldingLootcard = false
+                    end
+                end, card.Id)
+            else
+                lootdeck:AddCallback(table.unpack(callback))
+            end
+        end
+    end
+
+    helper.AddExternalItemDescriptionCard(card)
+
+	if Encyclopedia and card.WikiDescription and not card.Holographic then
+		local cardFrontPath = string.format("gfx/ui/lootcard_fronts/%s.png", card.Tag)
+		Encyclopedia.AddCard({
+			Class = "Loot Deck",
+			ID = card.Id,
+			WikiDesc = card.WikiDescription,
+			ModName = "Loot Deck",
+			Spr = Encyclopedia.RegisterSprite("gfx/ui/lootcard_fronts.anm2", card.HUDAnimationName, 0, cardFrontPath),
+		})
+	end
+end
+
+for _, challenge in pairs(lootdeckChallenges) do
+    if challenge.callbacks then
+        for _, callback in pairs(challenge.callbacks) do
+            lootdeck:AddCallback(table.unpack(callback))
+        end
+    end
+end
+
+for _, variant in pairs(entityVariants) do
+    if variant.callbacks then
+        for _, callback in pairs(variant.callbacks) do
+            lootdeck:AddCallback(table.unpack(callback))
+        end
+    end
+end
+
+for _, subType in pairs(entitySubTypes) do
+    if subType.callbacks then
+        for _, callback in pairs(subType.callbacks) do
+            lootdeck:AddCallback(table.unpack(callback))
+        end
+    end
+end
+
+for _, item in pairs(items) do
+    if item.callbacks then
+        for _, callback in pairs(item.callbacks) do
+            lootdeck:AddCallback(table.unpack(callback))
+        end
+    end
+
+	helper.AddExternalItemDescriptionItem(item)
+
+	if Encyclopedia and item.WikiDescription then
+		Encyclopedia.AddItem({
+			Class = "Loot Deck",
+			ID = item.Id,
+			WikiDesc = item.WikiDescription,
+			ModName = "Loot Deck"
+		})
+	end
+end
+
+for _, trinket in pairs(trinkets) do
+    if trinket.callbacks then
+        for _, callback in pairs(trinket.callbacks) do
+            lootdeck:AddCallback(table.unpack(callback))
+        end
+    end
+
+	helper.AddExternalItemDescriptionTrinket(trinket)
+
+	if Encyclopedia and trinket.WikiDescription then
+		Encyclopedia.AddTrinket({
+			Class = "Loot Deck",
+			ID = trinket.Id,
+			WikiDesc = trinket.WikiDescription,
+			ModName = "Loot Deck"
+		})
+	end
+end
+
+for _, trinket in pairs(trinkets) do
+    if trinket.callbacks then
+        for _, callback in pairs(trinket.callbacks) do
+            lootdeck:AddCallback(table.unpack(callback))
+        end
+    end
+end

--- a/main.lua
+++ b/main.lua
@@ -366,7 +366,7 @@ lootdeck:AddCallback(ModCallbacks.MC_POST_PLAYER_RENDER, function(_, p)
 
     if not Game():IsPaused() then
         if data.lootcardPickupAnimation then
-            if data.isHoldingLootcard and helper.TableContains(cardExtraAnimations, data.previousExtraAnimation) and data.lootcardPickupAnimation.sprite:IsPlaying(data.lootcardPickupAnimation.sprite:GetAnimation()) then
+            if data.isHoldingLootcard and helper.TableContains(cardExtraAnimations, data.previousExtraAnimation) and not p:IsExtraAnimationFinished() and data.lootcardPickupAnimation.sprite:IsPlaying(data.lootcardPickupAnimation.sprite:GetAnimation()) then
                 if (Isaac.GetFrameCount() - data.lootcardPickupAnimation.frameCount) % 2 == 0 then
                     data.lootcardPickupAnimation.sprite:Update()
                 end
@@ -376,7 +376,7 @@ lootdeck:AddCallback(ModCallbacks.MC_POST_PLAYER_RENDER, function(_, p)
         end
 
         if data.lootcardUseAnimation then
-            if ((playerAnimation == "UseItem" and p:GetActiveItem() == items.lootDeck.Id) or helper.TableContains(cardExtraAnimations, data.previousExtraAnimation)) and data.lootcardUseAnimation.sprite:IsPlaying(data.lootcardUseAnimation.sprite:GetAnimation()) then
+            if ((playerAnimation == "UseItem" and p:GetActiveItem() == items.lootDeck.Id) or helper.TableContains(cardExtraAnimations, data.previousExtraAnimation)) and not p:IsExtraAnimationFinished() and data.lootcardUseAnimation.sprite:IsPlaying(data.lootcardUseAnimation.sprite:GetAnimation()) then
                 if (Isaac.GetFrameCount() - data.lootcardUseAnimation.frameCount) % 2 == 0 then
                     data.lootcardUseAnimation.sprite:Update()
                 end


### PR DESCRIPTION
Resolves #344 

**Test**
- [x] Pickup
- [x] Use
- [x] Use with mimics like blank card
- [x] Teleport onto a lootcard, then take damage
- [x] Teleport onto a lootcard, then use an item
- [x] Teleport onto a lootcard, then use another lootcard
- [x] Use a lootcard, then use an item
- [x] Use a lootcard, then pickup a normal card
- [x] Test loot deck
- [x] Test deck of cards
- [x] IDK play around with different scenarios where you like pickup or use a lootcard then play a different extra animation somehow to make sure none work