### PR TITLE
Swallowed Penny rework

### DIFF
--- a/items/swallowedPenny.lua
+++ b/items/swallowedPenny.lua
@@ -19,13 +19,24 @@ local function MC_ENTITY_TAKE_DMG(_, e)
     local rng = p:GetCollectibleRNG(Id)
     if p:HasCollectible(Id) then
         for i=1,p:GetCollectibleNum(Id) do
-            local effect = rng:RandomInt(2)
-            if effect == 0 then
-                helper.Spawn(EntityType.ENTITY_PICKUP, PickupVariant.PICKUP_COIN, CoinSubType.COIN_PENNY, p.Position, Vector.FromAngle(rng:RandomInt(360)), nil)
-				break
-			end
-        end
+            local tear = p:FireTear(p.Position, Vector.FromAngle(rng:RandomInt(360)) * 10, false, true, false, p, 2)
+			tear:ChangeVariant(TearVariant.COIN)
+			tear:GetData()[Id] = true
+			p:AddCoins(-1)
+			lootdeck.sfx:Play(SoundEffect.SOUND_LITTLE_SPIT, 1, 0)
+		end
     end
+end
+
+local function MC_POST_ENTITY_REMOVE(_, tear)
+	local tearData = tear:GetData()
+	print('hullo')
+	if tearData[Id] then
+		local effect = Isaac.Spawn(EntityType.ENTITY_EFFECT, EffectVariant.PLAYER_CREEP_HOLYWATER_TRAIL, 0, tear.Position, Vector.Zero, tear)
+		helper.Spawn(EntityType.ENTITY_PICKUP, PickupVariant.PICKUP_COIN, 0, tear.Position, tear.Velocity:Normalized(), tear)
+		effect:GetSprite().Scale = Vector(2,2)
+		tearData[Id] = nil
+	end
 end
 
 return {
@@ -40,6 +51,10 @@ return {
             ModCallbacks.MC_ENTITY_TAKE_DMG,
             MC_ENTITY_TAKE_DMG,
             EntityType.ENTITY_PLAYER
+        },
+		{
+            ModCallbacks.MC_POST_ENTITY_REMOVE,
+            MC_POST_ENTITY_REMOVE,
         }
     }
 }

--- a/items/swallowedPenny.lua
+++ b/items/swallowedPenny.lua
@@ -30,7 +30,6 @@ end
 
 local function MC_POST_ENTITY_REMOVE(_, tear)
 	local tearData = tear:GetData()
-	print('hullo')
 	if tearData[Id] then
 		local effect = Isaac.Spawn(EntityType.ENTITY_EFFECT, EffectVariant.PLAYER_CREEP_HOLYWATER_TRAIL, 0, tear.Position, Vector.Zero, tear)
 		helper.Spawn(EntityType.ENTITY_PICKUP, PickupVariant.PICKUP_COIN, 0, tear.Position, tear.Velocity:Normalized(), tear)


### PR DESCRIPTION
On damage:
Lose 1 penny
Fire a coin tear in a random direction
When coin tear lands, create blue creep puddle and spawn a penny

more copies = more tears fired