### PR TITLE
Updated mimic charges for Jera, Counterfeit Penny, and Swallowed Penny

### DIFF
--- a/content/pocketitems.xml
+++ b/content/pocketitems.xml
@@ -406,7 +406,7 @@
 				description="Duplicate them"
 				hud="Jera"
 				type="special"
-				mimiccharge="1"
+				mimiccharge="4"
 				pickup="904"
 		/>
 	<card name="Pills!"

--- a/content/pocketitems.xml
+++ b/content/pocketitems.xml
@@ -147,14 +147,14 @@
         description="Take damage, gain money"
         hud="Swallowed Penny"
 				type="special"
-				mimiccharge="4"
+				mimiccharge="6"
 				pickup="904"
     />
 	<card name="Counterfeit Penny"
         description="Gain additional money"
 				hud="Counterfeit Penny"
 				type="special"
-				mimiccharge="4"
+				mimiccharge="12"
 				pickup="904"
     />
 	<card name="Cain's Eye"


### PR DESCRIPTION
Jera: 1 to 4
Counterfeit Penny: 4 to 12
Swallow Penny: 4 to 6
Resolves #413 